### PR TITLE
Add error description when writing received file

### DIFF
--- a/ApprovalTests.Swift/writers/ApprovalTextWriter.swift
+++ b/ApprovalTests.Swift/writers/ApprovalTextWriter.swift
@@ -21,11 +21,34 @@ class ApprovalTextWriter: ApprovalWriter {
 
     func writeReceivedFile(received: String) -> String {
         let fileUrl = URL(fileURLWithPath: received)
+        print("FileURL=\(fileUrl)|")
+        print("FileURL PTH=\(fileUrl.path)|")
         do {
+            
             try text.write(toFile: fileUrl.path, atomically: true, encoding: .utf8)
+            
         } catch {
-            print("An error occured writing file:" + received + "\(error.localizedDescription)")
+            print("ERROR=\(error)")
+            print("ERROR LD=\(error.localizedDescription)")
+            print("An error occured writing file:" + received)
         }
+        
+        
+        let str = "Super long string here"
+        let filename = getDocumentsDirectory().appendingPathComponent("output.txt")
+
+        do {
+            try str.write(to: filename, atomically: true, encoding: .utf8)
+        } catch {
+            // failed to write file – bad permissions, bad filename, missing permissions, or more likely it can't be converted to the encoding
+        }
+        
         return fileUrl.path
     }
+    
+    func getDocumentsDirectory() -> URL {
+        let paths = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)
+        return paths[0]
+    }
+    
 }

--- a/ApprovalTests.Swift/writers/ApprovalTextWriter.swift
+++ b/ApprovalTests.Swift/writers/ApprovalTextWriter.swift
@@ -24,7 +24,7 @@ class ApprovalTextWriter: ApprovalWriter {
         do {
             try text.write(toFile: fileUrl.path, atomically: true, encoding: .utf8)
         } catch {
-            print("An error occured writing file:" + received)
+            print("An error occured writing file:" + received + "\(error.localizedDescription)")
         }
         return fileUrl.path
     }

--- a/ApprovalTests.Swift/writers/ApprovalTextWriter.swift
+++ b/ApprovalTests.Swift/writers/ApprovalTextWriter.swift
@@ -21,19 +21,8 @@ class ApprovalTextWriter: ApprovalWriter {
 
     func writeReceivedFile(received: String) -> String {
         let fileUrl = URL(fileURLWithPath: received)
-        print("Received=\(received)")
-        print("FileURL=\(fileUrl)|")
-        print("FileURL PTH=\(fileUrl.path)|")
         do {
-            
-            //try text.write(toFile: fileUrl.path, atomically: true, encoding: .utf8)
-            let fileName = fileUrl.lastPathComponent
-            print("filename=\(fileName)")
- 
-            let fileUrl2 = URL(fileURLWithPath: "/Users/nicolas/Downloads/approvals/approvalsTests/Demo/testFile.txt")
-            try text.write(toFile: fileUrl2.path, atomically: true, encoding: .utf8)
-            
-            
+            try text.write(toFile: fileUrl.path, atomically: true, encoding: .utf8)
         } catch {
             print("An error occured writing file:" + received)
             print("ERROR=\(error)")

--- a/ApprovalTests.Swift/writers/ApprovalTextWriter.swift
+++ b/ApprovalTests.Swift/writers/ApprovalTextWriter.swift
@@ -26,12 +26,12 @@ class ApprovalTextWriter: ApprovalWriter {
         print("FileURL PTH=\(fileUrl.path)|")
         do {
             
-            try text.write(toFile: fileUrl.path, atomically: true, encoding: .utf8)
+            //try text.write(toFile: fileUrl.path, atomically: true, encoding: .utf8)
             let fileName = fileUrl.lastPathComponent
             print("filename=\(fileName)")
  
             let fileUrl2 = URL(fileURLWithPath: "/Users/nicolas/Downloads/approvals/approvalsTests/Demo/testFile.txt")
-            //try text.write(toFile: fileUrl2.path, atomically: true, encoding: .utf8)
+            try text.write(toFile: fileUrl2.path, atomically: true, encoding: .utf8)
             
             
         } catch {

--- a/ApprovalTests.Swift/writers/ApprovalTextWriter.swift
+++ b/ApprovalTests.Swift/writers/ApprovalTextWriter.swift
@@ -26,12 +26,12 @@ class ApprovalTextWriter: ApprovalWriter {
         print("FileURL PTH=\(fileUrl.path)|")
         do {
             
-            //try text.write(toFile: fileUrl.path, atomically: true, encoding: .utf8)
+            try text.write(toFile: fileUrl.path, atomically: true, encoding: .utf8)
             let fileName = fileUrl.lastPathComponent
             print("filename=\(fileName)")
  
-            let fileUrl2 = URL(fileURLWithPath: "/Users/nicolas/Downloads/approvals/testFile.txt")
-            try text.write(toFile: fileUrl2.path, atomically: true, encoding: .utf8)
+            let fileUrl2 = URL(fileURLWithPath: "/Users/nicolas/Downloads/approvals/approvalsTests/Demo/testFile.txt")
+            //try text.write(toFile: fileUrl2.path, atomically: true, encoding: .utf8)
             
             
         } catch {

--- a/ApprovalTests.Swift/writers/ApprovalTextWriter.swift
+++ b/ApprovalTests.Swift/writers/ApprovalTextWriter.swift
@@ -21,34 +21,26 @@ class ApprovalTextWriter: ApprovalWriter {
 
     func writeReceivedFile(received: String) -> String {
         let fileUrl = URL(fileURLWithPath: received)
+        print("Received=\(received)")
         print("FileURL=\(fileUrl)|")
         print("FileURL PTH=\(fileUrl.path)|")
         do {
             
-            try text.write(toFile: fileUrl.path, atomically: true, encoding: .utf8)
+            //try text.write(toFile: fileUrl.path, atomically: true, encoding: .utf8)
+            let fileName = fileUrl.lastPathComponent
+            print("filename=\(fileName)")
+ 
+            let fileUrl2 = URL(fileURLWithPath: "/Users/nicolas/Downloads/approvals/testFile.txt")
+            try text.write(toFile: fileUrl2.path, atomically: true, encoding: .utf8)
+            
             
         } catch {
-            print("ERROR=\(error)")
-            print("ERROR LD=\(error.localizedDescription)")
             print("An error occured writing file:" + received)
+            print("ERROR=\(error)")
         }
-        
-        
-        let str = "Super long string here"
-        let filename = getDocumentsDirectory().appendingPathComponent("output.txt")
 
-        do {
-            try str.write(to: filename, atomically: true, encoding: .utf8)
-        } catch {
-            // failed to write file – bad permissions, bad filename, missing permissions, or more likely it can't be converted to the encoding
-        }
-        
         return fileUrl.path
     }
-    
-    func getDocumentsDirectory() -> URL {
-        let paths = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)
-        return paths[0]
-    }
+
     
 }


### PR DESCRIPTION
## This should be small

Add error description when writing the received file.

## But it's not small!

If Approval cannot write the received file, the message only prompts an error.
This should also display the actual error message.
