### PR TITLE
iOSApprovalsWatcher.py: Update to use python3

### DIFF
--- a/iOSApprovalsWatcher.py
+++ b/iOSApprovalsWatcher.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 import argparse
 import datetime
 import os
@@ -70,5 +70,5 @@ if __name__ == '__main__':
     args = parse_arguments()
     watched_files = watchlist(args.test_directory, 'command.sh')
     remove(watched_files)
-    print 'Ready for iOS Approval Tests. Control-C to quit.'
+    print('Ready for iOS Approval Tests. Control-C to quit.')
     monitor_files(watched_files)


### PR DESCRIPTION
## Description

The watcher script would not run on my environment because I have python3 instead of python

## The solution

I've updated the python script to use python3 instead.
I think there may be a risk make a change this way and I thought it could be better to have a dedicate python3 watcher to allow people still using older versions continue working with ApprovalTests
I would be glad to know what you think about this 🙏 


