### PR TITLE
Added that the command.sh is removed after the diff tool was opened.

### DIFF
--- a/ApprovalTests.Swift/Writers/ApprovalTextWriter.swift
+++ b/ApprovalTests.Swift/Writers/ApprovalTextWriter.swift
@@ -20,6 +20,8 @@ public struct ApprovalTextWriter: ApprovalWriter {
     public func writeReceivedFile(_ received: String) {
         let fileURL = URL(fileURLWithPath: received)
         do {
+            let parent = fileURL.deletingLastPathComponent()
+            print("Directory exists? \(FileManager.default.fileExists(atPath: parent.path))")
             try text.write(toFile: fileURL.path, atomically: true, encoding: .utf8)
         } catch {
             print("Error in \(#function) for received \"\(received)\": \(error)")

--- a/iOSApprovalsWatcher.py
+++ b/iOSApprovalsWatcher.py
@@ -30,6 +30,8 @@ class WatchedFile:
                 print(self)
                 os.chmod(self.path, os.stat(self.path).st_mode | stat.S_IEXEC) 
                 subprocess.Popen(self.path)
+                time.sleep(0.5)
+                os.remove(self.path)
 
 
 def monitor_files(files):


### PR DESCRIPTION
## Description

When the Xcode project uses folder for the sources then the command.sh needs to be removed after the diff tool was started. Otherwise a second unit test run from Xcode results in an error because Xcode does not know what to do with the command.sh file.

## Summary by Sourcery

Modify the iOS Approvals Watcher to remove the command.sh script after launching the diff tool to prevent Xcode unit test run errors

Bug Fixes:
- Resolve Xcode unit test run issues caused by lingering command.sh files when using folder-based source configurations

Enhancements:
- Add a short delay and automatic removal of the command.sh script after launching the diff tool